### PR TITLE
Adding CSV ability

### DIFF
--- a/report_utils/mixins.py
+++ b/report_utils/mixins.py
@@ -8,6 +8,7 @@ from openpyxl.workbook import Workbook
 from openpyxl.writer.excel import save_virtual_workbook
 from openpyxl.cell import get_column_letter
 from openpyxl.styles import Font
+import csv
 import re
 from collections import namedtuple
 from decimal import Decimal
@@ -74,6 +75,22 @@ class DataExportMixin(object):
         response['Content-Length'] = myfile.tell()
         return response
 
+    def build_csv_response(self, wb, title="report"):
+        """ Take a workbook and return a csv file response """
+        if not title.endswith('.csv'):
+            title += '.csv'
+        myfile = BytesIO()
+        sh = wb.get_active_sheet()
+        c = csv.writer(myfile)
+        for r in sh.rows:
+            c.writerow([cell.value for cell in r])
+        response = HttpResponse(
+            myfile.getvalue(),
+            content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename=%s' % title
+        response['Content-Length'] = myfile.tell()
+        return response
+
     def list_to_workbook(self, data, title='report', header=None, widths=None):
         """ Create just a openpxl workbook from a list of data """
         wb = Workbook()
@@ -114,6 +131,13 @@ class DataExportMixin(object):
         """
         wb = self.list_to_workbook(data, title, header, widths)
         return self.build_xlsx_response(wb, title=title)
+
+    def list_to_csv_response(self, data, title='report', header=None,
+                              widths=None):
+        """ Make 2D list into a csv response for download data.
+        """
+        wb = self.list_to_workbook(data, title, header, widths)
+        return self.build_csv_response(wb, title=title)
 
     def add_aggregates(self, queryset, display_fields):
         agg_funcs = {


### PR DESCRIPTION
I tried to work on the ability to add CSV output for django-report-builder. I tried to make the changes to the codebase minimal. I also wanted to reduce duplication, and so I attempted at using the existing codebase and the functions made for the excel export in the CSV export.

A lot of the data export we need to do for my project relies on CSV. I was wondering if you could take a look at it. I'm happy to change things around. I tried to add functions that were just to build the CSV file, but found more success and less duplication by just using them.

I think the a limitation for CSV here is that it wouldn't have multiple sheets. However, I also couldn't figure out how there would be multiple sheets in the Excel sheet generation either.