### PR TITLE
Declare openpyxl as a dependence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
     install_requires=[
         'django',
         'six',
+        'openpyxl',
     ]
 )


### PR DESCRIPTION
I've come from `django-admin-export`, that uses this project. The export to xls function does not work with a 500 error, until `openpyxl` is installed by hand.
